### PR TITLE
fix: do not create empty GitHub issues

### DIFF
--- a/src/trivy.ts
+++ b/src/trivy.ts
@@ -30,6 +30,7 @@ export function scan(
     case 0:
       core.info(`Vulnerabilities were not found.
       Your maintenance looks good 👍`);
+      break;
     case 255:
       if (result.stdout && result.stdout.length > 0) {
         core.info('Vulnerabilities found !!!');


### PR DESCRIPTION
The action is creating empty GitHub issues regardless that non-vulnerabilities were found (exit code 0).

```
Vulnerabilities were not found.
      Your maintenance looks good 👍
Vulnerabilities found !!!
Found existing issue. Updating existing issue.
```