### PR TITLE
fix(node): add github url server for support Github Entreprise

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -7,7 +7,10 @@ export class GitHub {
   client: Octokit;
 
   constructor(token: string) {
-    this.client = new Octokit({ auth: token });
+    this.client = new Octokit({
+      auth: token,
+      baseUrl: process.env['GITHUB_SERVER_URL'] + "/api/v3" || 'https://github.com/api/v3',
+    });
   }
 
   async getTrivyIssues(image: string, labels: string[] | undefined) {


### PR DESCRIPTION
Hello this modification permit to support Github Enterprise by default Octokit set only url github.com for set an entreprise github we need to set var baseurl with env var GITHUB URL

https://octokit.github.io/rest.js/v18