### PR TITLE
migration from "trivy" to "trivy image" command

### DIFF
--- a/src/trivy.ts
+++ b/src/trivy.ts
@@ -8,6 +8,7 @@ export function scan(
   option: TrivyCmdOption
 ): string | undefined {
   const args = [
+    'image',
     '--severity',
     option.severity,
     '--vuln-type',


### PR DESCRIPTION
`trivy` command behaves the same as `trivy image` for backward compatibility. But it was deprecated in v0.8.0. It's been more than a year and this option will be removed in v0.23.0 which is supposed to be released at the end of January 2022. Please migrate to `trivy image`.

https://github.com/aquasecurity/trivy/discussions/1515